### PR TITLE
Created missingness chunks, difference scores and data grouping chunks 

### DIFF
--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1887,9 +1887,9 @@ dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA
 freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_phq_retro)
 ```
 
-#PHQ - prepanspective
+#PHQ - prepandemic
 PHQ Missingness NAs per person - count and percentages
-```{r PHQ prepanspective missingness}
+```{r PHQ prepan missingness}
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
   mutate(
     na_per_person_phq_prepan =         # variable for NA per person
@@ -1913,41 +1913,104 @@ dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA
 freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_phq_prepan)
 ```
 
-
-
-
-Missingness per item
-```{r Missingness per item}
-dat.no.sex.no.gender.no.age.no.ibd.miss <- as.data.frame(colnames(dat.no.sex.no.gender.no.age.no.ibd[,PHQ.items]))
-colnames(dat.no.sex.no.gender.no.age.no.ibd.miss) <- "Items"
-dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss <- colSums(is.na(dat.no.sex.no.gender.no.age.no.ibd[,PHQ.items]))
-dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss.pc <- dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss/nrow(dat.no.sex.no.gender.no.age.no.ibd[,PHQ.items])
-table(dat.no.sex.no.gender.no.age.no.ibd.miss$Items, dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss.pc)
-summary(dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss.pc)
-
-
-ggplot(data = dat.no.sex.no.gender.no.age.no.ibd.miss,
-       aes(x = Items, y = item.miss.pc)) +
-  geom_point() +
-  labs(title = "GLAD: PHQ",
-    y ="Missingness per item") +
-  theme_minimal() +
-  coord_flip()
-```
-
-```{r count of people missing a number of items}
-table(dat.no.sex.no.gender.no.age.no.ibd$na.per.person.phq)
+Count for PHQ baseline, retrospective, and prepandemic missingness per person
+```{r count of people missing a number of items for PHQ}
+#baseline
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_phq_base)
+#retrospective
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_phq_retro)
+#pre-pandemic
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_phq_prepan)
 ```
 
 
+#GAD - baseline
+GAD Missingness NAs per person - count and percentages
+```{r gad basline missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_gad_base =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the gad items at baseline
+           %in%
+             gad.items_base]
+        )
+    )
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_base) #have a look at the frequency 
 
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_gad_base = 
+      na_per_person_gad_base/7 # NA per person divided by the amount of items
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_gad_base)
+```
 
+#gad - retrospective
+gad Missingness NAs per person - count and percentages
+```{r gad retrospective missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_gad_retro =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the gad items at retroline
+           %in%
+             gad.items_retro]
+        )
+    )
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_retro) #have a look at the frequency 
 
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_gad_retro = 
+      na_per_person_gad_retro/7 # NA per person divided by the amount of items
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_gad_retro)
+```
 
+#gad - prepandemic
+gad Missingness NAs per person - count and percentages
+```{r gad prepan missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_gad_prepan =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the gad items at prepanline
+           %in%
+             gad.items_prepan]
+        )
+    )
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_prepan) #have a look at the frequency 
+
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_gad_prepan = 
+      na_per_person_gad_prepan/7 # NA per person divided by the amount of items
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_gad_prepan)
+```
+
+Count for gad baseline, retrospective, and prepandemic missingness per person
+```{r count of people missing a number of items for gad}
+#baseline
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_base)
+#retrospective
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_retro)
+#pre-pandemic
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_prepan)
+```
 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -2389,7 +2389,6 @@ summary(dat.glad$phq.diff_score_base_retro)
 
 ```
 
-
 GAD difference scores
 ```{r gad difference scores}
 # Difference score for prepandemic and retrospective gad sum scores
@@ -2427,8 +2426,20 @@ summary(dat.glad$gad.diff_score_base_retro)
 
 ```
 
+PCL difference scores
+NOTE: Only computed baseline and prepandemic differences as the retro account here isn't actually retrospective, but whether the reported baseline scores are due to the pandemic. 
+```{r pcl difference scores}
+# Difference score for prepandemic and baseline pcl sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    pcl.diff_score_prepan_base =
+      as.numeric(
+        pcl.sum_score_prepan - pcl.sum_score_base  # prepandemic sum score MINUS baseline sum score 
+      )
+  )
 
-
+summary(dat.glad$pcl.diff_score_prepan_base)
+```
 
 
 #Data level groups

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -2351,10 +2351,85 @@ table(dat.glad$over_one_year_time_diff_sign_up_coping)
 ```
 
 
-#Total score comparison between PHQ, PCL and GAD
-```{r pre, base, retro comparison for phq, pcl and gad}
-#see Issue for more details here
+#Total score comparison between PHQ, PCL and GAD, prepandemic, retrospecive and baseline
+PHQ difference scores
+```{r phq difference scores}
+# Difference score for prepandemic and retrospective phq sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    phq.diff_score_prepan_retro =
+      as.numeric(
+        phq.sum_score_prepan - phq.sum_score_retro  # retrospective sum score MINUS prepandemic sum score 
+      )
+  )
+
+summary(dat.glad$phq.diff_score_prepan_retro)
+
+# Difference score for prepandemic and baseline phq sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    phq.diff_score_prepan_base =
+      as.numeric(
+        phq.sum_score_prepan - phq.sum_score_base  # prepandemic sum score MINUS baseline sum score 
+      )
+  )
+
+summary(dat.glad$phq.diff_score_prepan_base)
+
+# Difference score for retrospective and baseline phq sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    phq.diff_score_base_retro =
+      as.numeric(
+        phq.sum_score_base - phq.sum_score_retro  # baseline sum score MINUS retrospective sum score 
+      )
+  )
+
+summary(dat.glad$phq.diff_score_base_retro)
+
 ```
+
+
+GAD difference scores
+```{r gad difference scores}
+# Difference score for prepandemic and retrospective gad sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    gad.diff_score_prepan_retro =
+      as.numeric(
+        gad.sum_score_prepan - gad.sum_score_retro  # retrospective sum score MINUS prepandemic sum score 
+      )
+  )
+
+summary(dat.glad$gad.diff_score_prepan_retro)
+
+# Difference score for prepandemic and baseline gad sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    gad.diff_score_prepan_base =
+      as.numeric(
+        gad.sum_score_prepan - gad.sum_score_base  # prepandemic sum score MINUS baseline sum score 
+      )
+  )
+
+summary(dat.glad$gad.diff_score_prepan_base)
+
+# Difference score for retrospective and baseline gad sum scores
+dat.glad <- dat.glad %>%
+  mutate(
+    gad.diff_score_base_retro =
+      as.numeric(
+        gad.sum_score_base - gad.sum_score_retro  # baseline sum score MINUS retrospective sum score 
+      )
+  )
+
+summary(dat.glad$gad.diff_score_base_retro)
+
+```
+
+
+
+
 
 #Data level groups
 Identify which data (prepan, retro and baseline) each participant has
@@ -2368,9 +2443,9 @@ dat.glad <- dat.glad %>%
     data_group_full_numeric =
       case_when(
         !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_phq_retro == 0  & na_per_person_gad_retro == 0 & na_per_person_pcl_retro == 0 ~ 5,
-        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_pcl_retro == 0 ~ 4,
-        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_gad_retro == 0 ~ 3,
-        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_phq_retro == 0 ~ 2, #in GLAD, in COPING and have no missing PCL-retro items
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_pcl_retro == 0 ~ 4, #in GLAD, in COPING and have no missing PCL-retro items
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_gad_retro == 0 ~ 3, #in GLAD, in COPING and have no missing GAD-retro items
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_phq_retro == 0 ~ 2, #in GLAD, in COPING and have no missing PHQ-retro items
         !is.na(startDate.glad) & !is.na(startDate.coping.glad) ~ 1,
         !is.na(startDate.glad) & is.na(startDate.coping.glad) ~ 0
       )
@@ -2392,18 +2467,6 @@ dat.glad <- dat.glad %>%
 
 table(dat.glad$data_group_full)
 ```
-
-
-
-```{r}
-rowSums(                       
-        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
-          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the pcl items at prepanline
-           %in%
-             pcl.items_prepan]
-```
-
-
 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1834,10 +1834,7 @@ Exclusion of inflammatory bowel disease (IBD) BioResource (BR) cohort
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age
 ```
 
-
 #Missigness of questionnaire items
-+++CH: We need to discuss how we want to exclude these participants that are missing answers to the questionnaires
-
 Complete case data for PHQ, GAD and PCL - 3345 remaining, drop 35,036.
 ```{r complete cases only}
 all.items <- c(phq.items_prepan,
@@ -1855,20 +1852,83 @@ dat.no.sex.no.gender.no.age.no.ibd.complete.cases <- dat.no.sex.no.gender.no.age
 dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases)
 dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases)[1]
 ```
-Missingness for PHQ
-```{r phq missingness baseline}
-dat.no.sex.no.gender.no.age.no.ibd.phq.base <- dat.no.sex.no.gender.no.age.no.ibd %>%
-  mutate(
-    na.per.person.phq =
-      rowSums(is.na(dat.no.sex.no.gender.no.age.no.ibd[,colnames(dat.no.sex.no.gender.no.age.no.ibd) %in% phq.items_base]))
-  )   
 
-freq(dat.no.sex.no.gender.no.age.no.ibd.phq.base$na.per.person.phq)
-table(dat.no.sex.no.gender.no.age.no.ibd.phq.base$na.per.person.phq)
+PHQ
+Complete case data for PHQ baseline (COPING) - 9,260 remaining
+```{r complete cases phq base}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.base <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, phq.items_base ]),]
 
-PHQ.cc$miss_pc_total.phq <- PHQ.cc$na.per.person.phq/PHQ.n.items
-freq(PHQ.cc$miss_pc_total.phq)
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.base)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.base)[1]
 ```
+
+Complete case data for PHQ pre-pandemic (GLAD) - 37,308 remaining
+```{r complete cases phq prepan}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.prepan <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, phq.items_prepan ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.prepan)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.prepan)[1]
+```
+
+Complete case data for PHQ retrospective (COPING) - 9,262 remaining
+```{r complete cases phq retro}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.retro <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, phq.items_retro ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.retro)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.retro)[1]
+```
+
+GAD
+Complete case data for GAD baseline (COPING) - 12,457 remaining
+```{r complete cases gad base}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.base <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, gad.items_base ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.base)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.base)[1]
+```
+
+Complete case data for gad pre-pandemic (GLAD) - 36,149 remaining
+```{r complete cases gad prepan}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.prepan <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, gad.items_prepan ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.prepan)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.prepan)[1]
+```
+
+Complete case data for gad retrospective (COPING) - 8,930 remaining
+```{r complete cases gad retro}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.retro <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, gad.items_retro ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.retro)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.gad.retro)[1]
+```
+
+
+PCL
+Complete case data for PCL baseline (COPING) - 12,376 remaining
+```{r complete cases pcl base}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.base <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, pcl.items_base ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.base)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.base)[1]
+```
+
+Complete case data for PCL pre-pandemic (GLAD) - 35,176 remaining
+```{r complete cases pcl prepan}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.prepan <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, pcl.items_prepan ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.prepan)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.prepan)[1]
+```
+
+Complete case data for PCL retrospective (COPING) - 4,618 remaining
+```{r complete cases pcl retro}
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, pcl.items_retro ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro)[1]
+```
+
 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1950,8 +1950,8 @@ dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA
 freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_gad_base)
 ```
 
-#gad - retrospective
-gad Missingness NAs per person - count and percentages
+#GAD - retrospective
+GAD Missingness NAs per person - count and percentages
 ```{r gad retrospective missingness}
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
   mutate(
@@ -1976,8 +1976,8 @@ dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA
 freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_gad_retro)
 ```
 
-#gad - prepandemic
-gad Missingness NAs per person - count and percentages
+#GAD - prepandemic
+GAD Missingness NAs per person - count and percentages
 ```{r gad prepan missingness}
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
   mutate(
@@ -2011,6 +2011,104 @@ table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_retro)
 #pre-pandemic
 table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_gad_prepan)
 ```
+
+
+#PCL - baseline
+PCL Missingness NAs per person - count and percentages
+```{r pcl basline missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_pcl_base =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the pcl items at baseline
+           %in%
+             pcl.items_base]
+        )
+    )
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_base) #have a look at the frequency 
+
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_pcl_base = 
+      na_per_person_pcl_base/6 # NA per person divided by the amount of items
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_pcl_base)
+```
+
+#PCL - retrospective
+PCL Missingness NAs per person - count and percentages
+```{r pcl retrospective missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_pcl_retro =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the pcl items at retroline
+           %in%
+             pcl.items_retro]
+        )
+    )
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_retro) #have a look at the frequency 
+
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_pcl_retro = 
+      na_per_person_pcl_retro/6 # NA per person divided by the amount of items
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_pcl_retro)
+```
+
+#PCL - prepandemic
+pcl Missingness NAs per person - count and percentages
+```{r pcl prepan missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_pcl_prepan =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the pcl items at prepanline
+           %in%
+             pcl.items_prepan]
+        )
+    )
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_prepan) #have a look at the frequency 
+
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_pcl_prepan = 
+      na_per_person_pcl_prepan/6 # NA per person divided by the amount of items
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_pcl_prepan)
+```
+
+Count for pcl baseline, retrospective, and prepandemic missingness per person
+```{r count of people missing a number of items for pcl}
+#baseline
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_base)
+#retrospective
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_retro)
+#pre-pandemic
+table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_prepan)
+```
+
+
+
+
+
+
+
+
+
 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1837,7 +1837,7 @@ dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age
 ##Missigness of questionnaire items
 #PHQ - baseline
 PHQ Missingness NAs per person - count and percentages
-```{r Missingness}
+```{r PHQ basline missingness}
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
   mutate(
     na_per_person_phq_base =         # variable for NA per person
@@ -1861,20 +1861,57 @@ dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA
 freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_phq_base)
 ```
 
+#PHQ - retrospective
+PHQ Missingness NAs per person - count and percentages
+```{r PHQ retrospective missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_phq_retro =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the PHQ items at retroline
+           %in%
+             phq.items_retro]
+        )
+    )
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_phq_retro) #have a look at the frequency 
 
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_phq_retro = 
+      na_per_person_phq_retro/9 # NA per person divided by the amount of items
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_phq_retro)
+```
 
+#PHQ - prepanspective
+PHQ Missingness NAs per person - count and percentages
+```{r PHQ prepanspective missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_phq_prepan =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the PHQ items at prepanline
+           %in%
+             phq.items_prepan]
+        )
+    )
+  )
 
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_phq_prepan) #have a look at the frequency 
 
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_phq_prepan = 
+      na_per_person_phq_prepan/9 # NA per person divided by the amount of items
+  )
 
-
-
-
-
-
-
-
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_phq_prepan)
+```
 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1405,15 +1405,6 @@ summarytools::dfSummary(
   labels.col = F)
 ```
 
-
-```{r pre, base, retro comparison for phq, pcl and gad}
-#see Issue for more details here
-```
-
-```{r data level groups}
-
-```
-
 # COPING GLAD: PCL-6
 
 ```{r coping glad pcl cols}
@@ -2358,6 +2349,63 @@ dat.glad <- dat.glad %>%
 
 table(dat.glad$over_one_year_time_diff_sign_up_coping)
 ```
+
+
+#Total score comparison between PHQ, PCL and GAD
+```{r pre, base, retro comparison for phq, pcl and gad}
+#see Issue for more details here
+```
+
+#Data level groups
+Identify which data (prepan, retro and baseline) each participant has
+Has only prepandemic == 0
+prepandemic and baseline == 1
+prepandemic, baseline, and retrospective == 2
+++KT: not sure how best to categorise here so this may need some revision. 
+```{r data level groups}
+dat.glad <- dat.glad %>%
+  mutate(
+    data_group_full_numeric =
+      case_when(
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_phq_retro == 0  & na_per_person_gad_retro == 0 & na_per_person_pcl_retro == 0 ~ 5,
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_pcl_retro == 0 ~ 4,
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_gad_retro == 0 ~ 3,
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) & na_per_person_phq_retro == 0 ~ 2, #in GLAD, in COPING and have no missing PCL-retro items
+        !is.na(startDate.glad) & !is.na(startDate.coping.glad) ~ 1,
+        !is.na(startDate.glad) & is.na(startDate.coping.glad) ~ 0
+      )
+  )
+
+dat.glad <- dat.glad %>%
+  mutate(
+    data_group_full = 
+      recode_factor(
+        data_group_full_numeric,
+        "0" = "Only prepandemic data",
+        "1" = "Prepandemic and baseline data",
+        "2" = "Prepandemic, baseline and retrospective PHQ data",
+        "3" = "Prepandemic, baseline and retrospective GAD data",
+        "4" = "Prepandemic, baseline and retrospective PCL data",
+        "5" = "All prepandemic, baseline and retrospective data"
+      )
+  )
+
+table(dat.glad$data_group_full)
+```
+
+
+
+```{r}
+rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the pcl items at prepanline
+           %in%
+             pcl.items_prepan]
+```
+
+
+
+
 
 #READ IN RESPIRATORY DATA 
 ```{r read in respiratory data}

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1834,7 +1834,91 @@ Exclusion of inflammatory bowel disease (IBD) BioResource (BR) cohort
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age
 ```
 
-#Missigness of questionnaire items
+##Missigness of questionnaire items
+#PHQ - baseline
+PHQ Missingness NAs per person - count and percentages
+```{r Missingness}
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na_per_person_phq_base =         # variable for NA per person
+      rowSums(                       
+        is.na(dat.no.sex.no.gender.no.age.no.ibd # sum the rows that are NA
+          [,colnames(dat.no.sex.no.gender.no.age.no.ibd) #for all the rows and columns that are in the PHQ items at baseline
+           %in%
+             phq.items_base]
+        )
+    )
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_phq_base) #have a look at the frequency 
+
+dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age.no.ibd %>% #NA per person as a percentage
+  mutate(
+    miss_pc_total_phq_base = 
+      na_per_person_phq_base/9 # NA per person divided by the amount of items
+  )
+
+freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_phq_base)
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Missingness per item
+```{r Missingness per item}
+dat.no.sex.no.gender.no.age.no.ibd.miss <- as.data.frame(colnames(dat.no.sex.no.gender.no.age.no.ibd[,PHQ.items]))
+colnames(dat.no.sex.no.gender.no.age.no.ibd.miss) <- "Items"
+dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss <- colSums(is.na(dat.no.sex.no.gender.no.age.no.ibd[,PHQ.items]))
+dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss.pc <- dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss/nrow(dat.no.sex.no.gender.no.age.no.ibd[,PHQ.items])
+table(dat.no.sex.no.gender.no.age.no.ibd.miss$Items, dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss.pc)
+summary(dat.no.sex.no.gender.no.age.no.ibd.miss$item.miss.pc)
+
+
+ggplot(data = dat.no.sex.no.gender.no.age.no.ibd.miss,
+       aes(x = Items, y = item.miss.pc)) +
+  geom_point() +
+  labs(title = "GLAD: PHQ",
+    y ="Missingness per item") +
+  theme_minimal() +
+  coord_flip()
+```
+
+```{r count of people missing a number of items}
+table(dat.no.sex.no.gender.no.age.no.ibd$na.per.person.phq)
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 Complete case data for PHQ, GAD and PCL - 3345 remaining, drop 35,036.
 ```{r complete cases only}
 all.items <- c(phq.items_prepan,
@@ -1852,6 +1936,7 @@ dat.no.sex.no.gender.no.age.no.ibd.complete.cases <- dat.no.sex.no.gender.no.age
 dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases)
 dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases)[1]
 ```
+
 
 PHQ
 Complete case data for PHQ baseline (COPING) - 9,260 remaining
@@ -1877,6 +1962,7 @@ dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.retro <- dat.no.sex.no.gen
 dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.retro)
 dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.phq.retro)[1]
 ```
+
 
 GAD
 Complete case data for GAD baseline (COPING) - 12,457 remaining
@@ -1929,22 +2015,15 @@ dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro)
 dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro)[1]
 ```
 
+Missingness NAs per person - count and percentages
+```{r DEM Missingness}
+dat.no.sex.no.gender.no.age.no.ibd$na.per.person.phq <- rowSums(is.na(dat.no.sex.no.gender.no.age.no.ibd[,colnames(dat.no.sex.no.gender.no.age.no.ibd) %in% all.items]))
+freq(dat.no.sex.no.gender.no.age.no.ibd$na.per.person.phq)
 
 
-
-```{r Exclusion of participants because of missing questionnaire items}
-dim(dat.no.sex.no.age.no.ibd)
-dat.no.sex.no.age.no.ibd.incomplete.phq.questionnaire <- dat.no.sex.no.gender.no.age.no.ibd %>%
-  filter(!is.na(phq.items_prepan))
-
-
-dim(dat.no.sex.no.age.no.ibd.incomplete.questionnaire)
-
-dim(dat.no.sex.no.age.no.ibd)[1]-dim(dat.no.sex.no.age.no.ibd.incomplete.questionnaire)[1]
-
-dat.no.sex.no.gender.no.age.no.ibd.incomplete.questionnaire <- dat.no.sex.no.gender.no.age.no.ibd
+PHQ.cc$miss_pc_total.phq <- PHQ.cc$na.per.person.phq/PHQ.n.items
+freq(PHQ.cc$miss_pc_total.phq)
 ```
-
 
 
 Create tidy data on which the exclusion criteria have been applied
@@ -1953,10 +2032,6 @@ dat.glad <- dat.no.sex.no.gender.no.age.no.ibd.incomplete.questionnaire
 
 skimr::skim(dat.glad)
 ```
-
-
-
-
 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -1405,9 +1405,6 @@ summarytools::dfSummary(
   labels.col = F)
 ```
 
-********************** 
-++KT LEFT OFF HERE
-**********************
 
 ```{r pre, base, retro comparison for phq, pcl and gad}
 #see Issue for more details here
@@ -1837,22 +1834,58 @@ Exclusion of inflammatory bowel disease (IBD) BioResource (BR) cohort
 dat.no.sex.no.gender.no.age.no.ibd <- dat.no.sex.no.gender.no.age
 ```
 
+
 #Missigness of questionnaire items
 +++CH: We need to discuss how we want to exclude these participants that are missing answers to the questionnaires
-```{r missingness}
 
+Complete case data for PHQ, GAD and PCL - 3345 remaining, drop 35,036.
+```{r complete cases only}
+all.items <- c(phq.items_prepan,
+                phq.items_base,
+                phq.items_retro,
+                gad.items_prepan,
+                gad.items_base,
+                gad.items_retro,
+                pcl.items_prepan,
+                pcl.items_base,
+                pcl.items_retro)
+
+dat.no.sex.no.gender.no.age.no.ibd.complete.cases <- dat.no.sex.no.gender.no.age.no.ibd[complete.cases(dat.no.sex.no.gender.no.age.no.ibd[, all.items ]),]
+
+dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases)
+dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases)[1]
+```
+Missingness for PHQ
+```{r phq missingness baseline}
+dat.no.sex.no.gender.no.age.no.ibd.phq.base <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  mutate(
+    na.per.person.phq =
+      rowSums(is.na(dat.no.sex.no.gender.no.age.no.ibd[,colnames(dat.no.sex.no.gender.no.age.no.ibd) %in% phq.items_base]))
+  )   
+
+freq(dat.no.sex.no.gender.no.age.no.ibd.phq.base$na.per.person.phq)
+table(dat.no.sex.no.gender.no.age.no.ibd.phq.base$na.per.person.phq)
+
+PHQ.cc$miss_pc_total.phq <- PHQ.cc$na.per.person.phq/PHQ.n.items
+freq(PHQ.cc$miss_pc_total.phq)
 ```
 
+
+
 ```{r Exclusion of participants because of missing questionnaire items}
-#dim(dat.no.sex.no.age.no.ibd)
-#dat.no.sex.no.age.no.ibd.incomplete.questionnaire <- dat.no.sex.no.age.no.ibd %>%
-#  filter(#ADD CONDITION HERE)
-#dim(dat.no.sex.no.age.no.ibd.incomplete.questionnaire)
-#
-#dim(dat.no.sex.no.age.no.ibd)[1]-dim(dat.no.sex.no.age.no.ibd.incomplete.questionnaire)[1]
+dim(dat.no.sex.no.age.no.ibd)
+dat.no.sex.no.age.no.ibd.incomplete.phq.questionnaire <- dat.no.sex.no.gender.no.age.no.ibd %>%
+  filter(!is.na(phq.items_prepan))
+
+
+dim(dat.no.sex.no.age.no.ibd.incomplete.questionnaire)
+
+dim(dat.no.sex.no.age.no.ibd)[1]-dim(dat.no.sex.no.age.no.ibd.incomplete.questionnaire)[1]
 
 dat.no.sex.no.gender.no.age.no.ibd.incomplete.questionnaire <- dat.no.sex.no.gender.no.age.no.ibd
 ```
+
+
 
 Create tidy data on which the exclusion criteria have been applied
 ```{r Tidy data}
@@ -1860,6 +1893,14 @@ dat.glad <- dat.no.sex.no.gender.no.age.no.ibd.incomplete.questionnaire
 
 skimr::skim(dat.glad)
 ```
+
+
+
+
+
+
+
+
 The complete rate for sex, gender and age should be 1 now. 
 
 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -2201,7 +2201,6 @@ dat.glad <- dat.no.sex.no.gender.no.age.no.ibd.missingness
 skimr::skim(dat.glad)
 ```
 
-
 # Definition of prepandemic and baseline 
 Exlcude people who have joined GLAD/EDGI after the pandemic began, sensitivity analyses done on the cut off's we have chosen. 
 Potentially GLAD/EDGI particiapnts between January to April. EDGI launched on February 24th. 
@@ -2304,7 +2303,6 @@ dat.glad %>%
   freq(prepandemic_march_23)
 ```
 
-
 Calculate the time difference between time difference between sign up questionnaire and COPING questionnaire
 ```{r time difference between sign up questionnaire and COPING questionnaire}
 dat.glad <- dat.glad %>%
@@ -2324,7 +2322,6 @@ dat.glad %>%
     stats = "common"
     )
 ```
-
 
 Proportion of people signed up over one year ago
 ```{r eval=FALSE, include=FALSE}
@@ -2349,7 +2346,6 @@ dat.glad <- dat.glad %>%
 
 table(dat.glad$over_one_year_time_diff_sign_up_coping)
 ```
-
 
 #Total score comparison between PHQ, PCL and GAD, prepandemic, retrospecive and baseline
 PHQ difference scores
@@ -2441,12 +2437,8 @@ dat.glad <- dat.glad %>%
 summary(dat.glad$pcl.diff_score_prepan_base)
 ```
 
-
 #Data level groups
-Identify which data (prepan, retro and baseline) each participant has
-Has only prepandemic == 0
-prepandemic and baseline == 1
-prepandemic, baseline, and retrospective == 2
+Identify which data (prepan, retro and baseline) each participant has.
 ++KT: not sure how best to categorise here so this may need some revision. 
 ```{r data level groups}
 dat.glad <- dat.glad %>%
@@ -2478,7 +2470,6 @@ dat.glad <- dat.glad %>%
 
 table(dat.glad$data_group_full)
 ```
-
 
 
 #READ IN RESPIRATORY DATA 

--- a/PANCHANGE_data_preprocessing2020-07-15.Rmd
+++ b/PANCHANGE_data_preprocessing2020-07-15.Rmd
@@ -2093,30 +2093,18 @@ freq(dat.no.sex.no.gender.no.age.no.ibd$miss_pc_total_pcl_prepan)
 
 Count for pcl baseline, retrospective, and prepandemic missingness per person
 ```{r count of people missing a number of items for pcl}
-#baseline
+# baseline
 table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_base)
-#retrospective
+# retrospective
 table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_retro)
-#pre-pandemic
+# pre-pandemic
 table(dat.no.sex.no.gender.no.age.no.ibd$na_per_person_pcl_prepan)
+
+# rename dataset
+dat.no.sex.no.gender.no.age.no.ibd.missingness <- dat.no.sex.no.gender.no.age.no.ibd
 ```
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+#Creating "complete cases" datasets  - NOTE THIS PROBABLY WONT BE USED BUT JUST TO GIVE AN IDEA OF COMPLETE CASES NUMBERS. KT. 
 Complete case data for PHQ, GAD and PCL - 3345 remaining, drop 35,036.
 ```{r complete cases only}
 all.items <- c(phq.items_prepan,
@@ -2213,28 +2201,14 @@ dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro)
 dim(dat.no.sex.no.gender.no.age.no.ibd)[1]-dim(dat.no.sex.no.gender.no.age.no.ibd.complete.cases.pcl.retro)[1]
 ```
 
-Missingness NAs per person - count and percentages
-```{r DEM Missingness}
-dat.no.sex.no.gender.no.age.no.ibd$na.per.person.phq <- rowSums(is.na(dat.no.sex.no.gender.no.age.no.ibd[,colnames(dat.no.sex.no.gender.no.age.no.ibd) %in% all.items]))
-freq(dat.no.sex.no.gender.no.age.no.ibd$na.per.person.phq)
 
-
-PHQ.cc$miss_pc_total.phq <- PHQ.cc$na.per.person.phq/PHQ.n.items
-freq(PHQ.cc$miss_pc_total.phq)
-```
-
-
-Create tidy data on which the exclusion criteria have been applied
+##Create tidy data on which the exclusion criteria have been applied
+Complete sex, gender, age and missingness information applied. 
 ```{r Tidy data}
-dat.glad <- dat.no.sex.no.gender.no.age.no.ibd.incomplete.questionnaire
+dat.glad <- dat.no.sex.no.gender.no.age.no.ibd.missingness
 
 skimr::skim(dat.glad)
 ```
-
-
-
-
-The complete rate for sex, gender and age should be 1 now. 
 
 
 # Definition of prepandemic and baseline 
@@ -2384,6 +2358,13 @@ dat.glad <- dat.glad %>%
 
 table(dat.glad$over_one_year_time_diff_sign_up_coping)
 ```
+
+#READ IN RESPIRATORY DATA 
+```{r read in respiratory data}
+
+
+```
+
 
 # Probable COVID-19 case identification
 Algorithm from Menni et al. to identify probable COVID-19

--- a/PANCHANGE_workflow_2020-07-20.txt
+++ b/PANCHANGE_workflow_2020-07-20.txt
@@ -11,7 +11,9 @@ Workflow:
 - Make sure to attach each issue with the appropriate label. If there is an Issue that you think warrants discussion in a weekly meeting then make sure to add the tag "Meeting topic" and this will be discussed in the next meeting.  
 - Create a new branch when starting a new task and never edit the master script. 
 - Each team member can work simultaneously on the scripts using different branches, however make sure there is no task overlap.
-- All code will be reviewed by another member of the team before pushing to the master script. Therefore, make sure to assign a member of the team on Github to review your push. 
+- All code will be reviewed by another member of the team before pushing to the master script. Therefore, make sure to assign a member of the team on Github to review your push (pull request). 
+- Pull requests should be reviewed daily to avoid any clashing of work. If you have been assigned a review - please review this at the end of that day. 
+- When reviewing the pull requests, please delete the branch so that there are not random branches still open.
 
 Current labels: Administrative, Meeting topic, Analyses, Data cleaning, Data visualisation, Data merging, Sensitivity, Help needed, RAMP specific query, COPING specific query, GLAD specific query. 
 


### PR DESCRIPTION
@mollyrdavies @topherhuebel @klpurves 
I've created three new sections at the end of the processing script here. 
- I've created an item missingness variable e.g. 1 item missing from available 7, for the PHQ, GAD, PCL at baseline, retro and pre-pandemic. 
- I've created a grouping chunk to identify who has what data - this may need to be double checked to confirm we are happy with the way I identified each group. 
- I've created difference scores to compare prepan-baseline, baseline-retro, prepan-retro differences in total scores for GAD and PHQ (these will need to be checked to see if we're happy with the order of the subtraction, but it was kept consistent across measures). 
- For PCL I only created prepan-baseline difference scores as the retrospective account isn't measured in the same way as PHQ and GAD (these will need to be checked to see if we're happy with the order of the subtraction, but it was kept consistent across measures). 

Let me know if you have any questions when reviewing! 
