### PR TITLE
Add regressions klp

### DIFF
--- a/PANCHANGE_analysis.Rmd
+++ b/PANCHANGE_analysis.Rmd
@@ -1442,6 +1442,8 @@ b - overlapping disorder categories
 
 ## Prepan-baseline change
 
+### CHANGE SCORES
+
 ### GAD
 Model 0a: Disorder_hierarchical, Unadjusted
 ```{r GAD prepan Model 0a}
@@ -1730,6 +1732,298 @@ ocir_prepan_model1b <- lm(
 summary(ocir_prepan_model1b)
 tidy(ocir_prepan_model1b)
 ```
+
+### PANDEMIC BASELINE CONTROLLING FOR PREPANDEMIC
+
+### GAD
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r GAD prepan Model 0a}
+gad_prepan_model0a <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_prepan + 
+    Disorder_hierarchical,
+  data = dat.prepan)
+
+summary(gad_prepan_model0a)
+tidy(gad_prepan_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r GAD prepan Model 0b}
+gad_prepan_model0b <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.prepan)
+
+summary(gad_prepan_model0b)
+tidy(gad_prepan_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r GAD prepan Model 1a}
+gad_prepan_model1a <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_prepan + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(gad_prepan_model1a)
+tidy(gad_prepan_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r GAD prepan Model 1b}
+gad_prepan_model1b <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(gad_prepan_model1b)
+tidy(gad_prepan_model1b)
+```
+
+### PHQ
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r PHQ prepan Model 0a}
+phq_prepan_model0a <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_prepan + 
+    Disorder_hierarchical,
+  data = dat.prepan)
+
+summary(phq_prepan_model0a)
+tidy(phq_prepan_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r PHQ prepan Model 0b}
+phq_prepan_model0b <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.prepan)
+
+summary(phq_prepan_model0b)
+tidy(phq_prepan_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PHQ prepan Model 1a}
+phq_prepan_model1a <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_prepan + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(phq_prepan_model1a)
+tidy(phq_prepan_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PHQ prepan Model 1b}
+phq_prepan_model1b <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(phq_prepan_model1b)
+tidy(phq_prepan_model1b)
+```
+
+
+### PCL
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r PCL prepan Model 0a}
+pcl_prepan_model0a <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_prepan + 
+    Disorder_hierarchical,
+  data = dat.prepan)
+
+summary(pcl_prepan_model0a)
+tidy(pcl_prepan_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r PCL prepan Model 0b}
+pcl_prepan_model0b <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.prepan)
+
+summary(pcl_prepan_model0b)
+tidy(pcl_prepan_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PCL prepan Model 1a}
+pcl_prepan_model1a <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_prepan + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(pcl_prepan_model1a)
+tidy(pcl_prepan_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PCL prepan Model 1b}
+pcl_prepan_model1b <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(pcl_prepan_model1b)
+tidy(pcl_prepan_model1b)
+```
+
+### OCIR
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r OCIR prepan Model 0a}
+ocir_prepan_model0a <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_prepan + 
+    Disorder_hierarchical,
+  data = dat.prepan)
+
+summary(ocir_prepan_model0a)
+tidy(ocir_prepan_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r OCIR prepan Model 0b}
+ocir_prepan_model0b <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.prepan)
+
+summary(ocir_prepan_model0b)
+tidy(ocir_prepan_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r OCIR prepan Model 1a}
+ocir_prepan_model1a <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_prepan + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(ocir_prepan_model1a)
+tidy(ocir_prepan_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r OCIR prepan Model 1b}
+ocir_prepan_model1b <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_prepan +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.prepan)
+
+summary(ocir_prepan_model1b)
+tidy(ocir_prepan_model1b)
+```
+
 
 
 ## Retro-baseline change

--- a/PANCHANGE_analysis.Rmd
+++ b/PANCHANGE_analysis.Rmd
@@ -1737,7 +1737,7 @@ tidy(ocir_prepan_model1b)
 
 ### GAD
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r GAD prepan Model 0a}
+```{r GAD prepan Model absolute values absolute values 0a}
 gad_prepan_model0a <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_prepan + 
     Disorder_hierarchical,
@@ -1748,7 +1748,7 @@ tidy(gad_prepan_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r GAD prepan Model 0b}
+```{r GAD prepan Model absolute values 0b}
 gad_prepan_model0b <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_prepan +
     anxiety_disorders +
@@ -1770,7 +1770,7 @@ tidy(gad_prepan_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r GAD prepan Model 1a}
+```{r GAD prepan Model absolute values 1a}
 gad_prepan_model1a <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_prepan + 
     Disorder_hierarchical + 
@@ -1786,7 +1786,7 @@ tidy(gad_prepan_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r GAD prepan Model 1b}
+```{r GAD prepan Model absolute values 1b}
 gad_prepan_model1b <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_prepan +
     anxiety_disorders +
@@ -1809,7 +1809,7 @@ tidy(gad_prepan_model1b)
 
 ### PHQ
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r PHQ prepan Model 0a}
+```{r PHQ prepan Model absolute values 0a}
 phq_prepan_model0a <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_prepan + 
     Disorder_hierarchical,
@@ -1820,7 +1820,7 @@ tidy(phq_prepan_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r PHQ prepan Model 0b}
+```{r PHQ prepan Model absolute values 0b}
 phq_prepan_model0b <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_prepan +
     anxiety_disorders +
@@ -1842,7 +1842,7 @@ tidy(phq_prepan_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PHQ prepan Model 1a}
+```{r PHQ prepan Model absolute values 1a}
 phq_prepan_model1a <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_prepan + 
     Disorder_hierarchical + 
@@ -1858,7 +1858,7 @@ tidy(phq_prepan_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PHQ prepan Model 1b}
+```{r PHQ prepan Model absolute values 1b}
 phq_prepan_model1b <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_prepan +
     anxiety_disorders +
@@ -1882,7 +1882,7 @@ tidy(phq_prepan_model1b)
 
 ### PCL
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r PCL prepan Model 0a}
+```{r PCL prepan Model absolute values 0a}
 pcl_prepan_model0a <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_prepan + 
     Disorder_hierarchical,
@@ -1893,7 +1893,7 @@ tidy(pcl_prepan_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r PCL prepan Model 0b}
+```{r PCL prepan Model absolute values 0b}
 pcl_prepan_model0b <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_prepan +
     anxiety_disorders +
@@ -1915,7 +1915,7 @@ tidy(pcl_prepan_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PCL prepan Model 1a}
+```{r PCL prepan Model absolute values 1a}
 pcl_prepan_model1a <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_prepan + 
     Disorder_hierarchical + 
@@ -1931,7 +1931,7 @@ tidy(pcl_prepan_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PCL prepan Model 1b}
+```{r PCL prepan Model absolute values 1b}
 pcl_prepan_model1b <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_prepan +
     anxiety_disorders +
@@ -1954,7 +1954,7 @@ tidy(pcl_prepan_model1b)
 
 ### OCIR
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r OCIR prepan Model 0a}
+```{r OCIR prepan Model absolute values 0a}
 ocir_prepan_model0a <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_prepan + 
     Disorder_hierarchical,
@@ -1965,7 +1965,7 @@ tidy(ocir_prepan_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r OCIR prepan Model 0b}
+```{r OCIR prepan Model absolute values 0b}
 ocir_prepan_model0b <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_prepan +
     anxiety_disorders +
@@ -1987,7 +1987,7 @@ tidy(ocir_prepan_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r OCIR prepan Model 1a}
+```{r OCIR prepan Model absolute values 1a}
 ocir_prepan_model1a <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_prepan + 
     Disorder_hierarchical + 
@@ -2003,7 +2003,7 @@ tidy(ocir_prepan_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r OCIR prepan Model 1b}
+```{r OCIR prepan Model absolute values 1b}
 ocir_prepan_model1b <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_prepan +
     anxiety_disorders +
@@ -2336,7 +2336,7 @@ tidy(ocir_retro_model1b)
 
 ### GAD
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r GAD retro Model 0a}
+```{r GAD retro Model absolute values 0a}
 gad_retro_model0a <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_retro + 
     Disorder_hierarchical,
@@ -2347,7 +2347,7 @@ tidy(gad_retro_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r GAD retro Model 0b}
+```{r GAD retro Model absolute values 0b}
 gad_retro_model0b <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_retro +
     anxiety_disorders +
@@ -2369,7 +2369,7 @@ tidy(gad_retro_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r GAD retro Model 1a}
+```{r GAD retro Model absolute values 1a}
 gad_retro_model1a <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_retro + 
     Disorder_hierarchical + 
@@ -2385,7 +2385,7 @@ tidy(gad_retro_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r GAD retro Model 1b}
+```{r GAD retro Model absolute values 1b}
 gad_retro_model1b <- lm(
   formula = gad.sum_score_base ~ gad.sum_score_retro +
     anxiety_disorders +
@@ -2408,7 +2408,7 @@ tidy(gad_retro_model1b)
 
 ### PHQ
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r PHQ retro Model 0a}
+```{r PHQ retro Model absolute values 0a}
 phq_retro_model0a <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_retro + 
     Disorder_hierarchical,
@@ -2419,7 +2419,7 @@ tidy(phq_retro_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r PHQ retro Model 0b}
+```{r PHQ retro Model absolute values 0b}
 phq_retro_model0b <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_retro +
     anxiety_disorders +
@@ -2441,7 +2441,7 @@ tidy(phq_retro_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PHQ retro Model 1a}
+```{r PHQ retro Model absolute values 1a}
 phq_retro_model1a <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_retro + 
     Disorder_hierarchical + 
@@ -2457,7 +2457,7 @@ tidy(phq_retro_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PHQ retro Model 1b}
+```{r PHQ retro Model absolute values 1b}
 phq_retro_model1b <- lm(
   formula = phq.sum_score_base ~ phq.sum_score_retro +
     anxiety_disorders +
@@ -2481,7 +2481,7 @@ tidy(phq_retro_model1b)
 
 ### PCL
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r PCL retro Model 0a}
+```{r PCL retro Model absolute values 0a}
 pcl_retro_model0a <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_retro + 
     Disorder_hierarchical,
@@ -2492,7 +2492,7 @@ tidy(pcl_retro_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r PCL retro Model 0b}
+```{r PCL retro Model absolute values 0b}
 pcl_retro_model0b <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_retro +
     anxiety_disorders +
@@ -2514,7 +2514,7 @@ tidy(pcl_retro_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PCL retro Model 1a}
+```{r PCL retro Model absolute values 1a}
 pcl_retro_model1a <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_retro + 
     Disorder_hierarchical + 
@@ -2530,7 +2530,7 @@ tidy(pcl_retro_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r PCL retro Model 1b}
+```{r PCL retro Model absolute values 1b}
 pcl_retro_model1b <- lm(
   formula = pcl.sum_score_base ~ pcl.sum_score_retro +
     anxiety_disorders +
@@ -2553,7 +2553,7 @@ tidy(pcl_retro_model1b)
 
 ### OCIR
 Model 0a: Disorder_hierarchical, Unadjusted
-```{r OCIR retro Model 0a}
+```{r OCIR retro Model absolute values 0a}
 ocir_retro_model0a <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_retro + 
     Disorder_hierarchical,
@@ -2564,7 +2564,7 @@ tidy(ocir_retro_model0a)
 ```
 
 Model 0b: Overlapping disorders, Unadjusted
-```{r OCIR retro Model 0b}
+```{r OCIR retro Model absolute values 0b}
 ocir_retro_model0b <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_retro +
     anxiety_disorders +
@@ -2586,7 +2586,7 @@ tidy(ocir_retro_model0b)
 
 Model 1a: Disorder hierarchical, Adjusted
   Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r OCIR retro Model 1a}
+```{r OCIR retro Model absolute values 1a}
 ocir_retro_model1a <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_retro + 
     Disorder_hierarchical + 
@@ -2602,7 +2602,7 @@ tidy(ocir_retro_model1a)
 
 Model 1b: Overlapping disorders, Adjusted
   Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
-```{r OCIR retro Model 1b}
+```{r OCIR retro Model absolute values 1b}
 ocir_retro_model1b <- lm(
   formula = ocir.sum_score_base ~ ocir.sum_score_retro +
     anxiety_disorders +
@@ -2622,11 +2622,6 @@ ocir_retro_model1b <- lm(
 summary(ocir_retro_model1b)
 tidy(ocir_retro_model1b)
 ```
-
-
-
-
-
 
 
 

--- a/PANCHANGE_analysis.Rmd
+++ b/PANCHANGE_analysis.Rmd
@@ -2028,6 +2028,8 @@ tidy(ocir_prepan_model1b)
 
 ## Retro-baseline change
 
+### CHANGE SCORES
+
 ### GAD
 Model 0a: Disorder_hierarchical, Unadjusted
 ```{r GAD retro Model 0a}
@@ -2327,6 +2329,300 @@ ocir_retro_model1b <- lm(
 summary(ocir_retro_model1b)
 tidy(ocir_retro_model1b)
 ```
+
+
+
+### PANDEMIC BASELINE CONTROLLING FOR RETROSPECTIVE
+
+### GAD
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r GAD retro Model 0a}
+gad_retro_model0a <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_retro + 
+    Disorder_hierarchical,
+  data = dat.retro)
+
+summary(gad_retro_model0a)
+tidy(gad_retro_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r GAD retro Model 0b}
+gad_retro_model0b <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.retro)
+
+summary(gad_retro_model0b)
+tidy(gad_retro_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r GAD retro Model 1a}
+gad_retro_model1a <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_retro + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(gad_retro_model1a)
+tidy(gad_retro_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r GAD retro Model 1b}
+gad_retro_model1b <- lm(
+  formula = gad.sum_score_base ~ gad.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(gad_retro_model1b)
+tidy(gad_retro_model1b)
+```
+
+### PHQ
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r PHQ retro Model 0a}
+phq_retro_model0a <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_retro + 
+    Disorder_hierarchical,
+  data = dat.retro)
+
+summary(phq_retro_model0a)
+tidy(phq_retro_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r PHQ retro Model 0b}
+phq_retro_model0b <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.retro)
+
+summary(phq_retro_model0b)
+tidy(phq_retro_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PHQ retro Model 1a}
+phq_retro_model1a <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_retro + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(phq_retro_model1a)
+tidy(phq_retro_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PHQ retro Model 1b}
+phq_retro_model1b <- lm(
+  formula = phq.sum_score_base ~ phq.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(phq_retro_model1b)
+tidy(phq_retro_model1b)
+```
+
+
+### PCL
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r PCL retro Model 0a}
+pcl_retro_model0a <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_retro + 
+    Disorder_hierarchical,
+  data = dat.retro)
+
+summary(pcl_retro_model0a)
+tidy(pcl_retro_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r PCL retro Model 0b}
+pcl_retro_model0b <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.retro)
+
+summary(pcl_retro_model0b)
+tidy(pcl_retro_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PCL retro Model 1a}
+pcl_retro_model1a <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_retro + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(pcl_retro_model1a)
+tidy(pcl_retro_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r PCL retro Model 1b}
+pcl_retro_model1b <- lm(
+  formula = pcl.sum_score_base ~ pcl.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(pcl_retro_model1b)
+tidy(pcl_retro_model1b)
+```
+
+### OCIR
+Model 0a: Disorder_hierarchical, Unadjusted
+```{r OCIR retro Model 0a}
+ocir_retro_model0a <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_retro + 
+    Disorder_hierarchical,
+  data = dat.retro)
+
+summary(ocir_retro_model0a)
+tidy(ocir_retro_model0a)
+```
+
+Model 0b: Overlapping disorders, Unadjusted
+```{r OCIR retro Model 0b}
+ocir_retro_model0b <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder,
+  data = dat.retro)
+
+summary(ocir_retro_model0b)
+tidy(ocir_retro_model0b)
+```
+
+Model 1a: Disorder hierarchical, Adjusted
+  Model 0a + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r OCIR retro Model 1a}
+ocir_retro_model1a <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_retro + 
+    Disorder_hierarchical + 
+    Gender_collapsed + 
+    age_category + 
+    Ethnicity_collapsed + 
+    time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(ocir_retro_model1a)
+tidy(ocir_retro_model1a)
+```
+
+Model 1b: Overlapping disorders, Adjusted
+  Model 0b + Sex + Age + Ethnicity_collapsed + Time registration and baseline
+```{r OCIR retro Model 1b}
+ocir_retro_model1b <- lm(
+  formula = ocir.sum_score_base ~ ocir.sum_score_retro +
+    anxiety_disorders +
+    depressive_disorders +
+    depression_and_anxiety +
+    eating_disorders +
+    obsessive_compulsive_disorders +
+    psychotic_disorders +
+    mhd.mania_hypomania_bipolar_or_manicdepression +
+    mhd.posttraumatic_stress_disorder_ptsd +
+    autism_spectrum_disorder +
+    mhd.attention_deficit_hyperactivity_disorder +
+    mhd.personality_disorder +
+    Gender_collapsed + age_category + Ethnicity_collapsed + time_diff_sign_up_coping,
+  data = dat.retro)
+
+summary(ocir_retro_model1b)
+tidy(ocir_retro_model1b)
+```
+
 
 
 


### PR DESCRIPTION
Added the regressions using absolute pandemic score controlling for prepandemic / retrospective scores respectively. Renamed chunks so this should knit fine.

Please review and check that this knits and runs as expected @mollyrdavies  @topherhuebel 

Did not get around to stratifying by date of GLAD sign up.

Did not add time between pandemic and baseline to any models as likely to be confounded with time since GLAD sign up in the prepandemic analyses. 

Should consider which is the most appropriate to control for when.